### PR TITLE
Remove animation properties from reduced motion reminder

### DIFF
--- a/css/reminders.css
+++ b/css/reminders.css
@@ -53,8 +53,9 @@ category: navigation
 label: Reduced Motion
 
 note: |
-  1. Immediately jump any animation to the end point
-  2. Remove transitions & fixed background attachment
+  1. Immediately jump any transition to the end point.
+     *Note* be careful with blanket turning off any and all motion.
+  2. Remove smooth scrolling & fixed background attachment.
 
 links:
   - https://github.com/mozdevs/cssremedy/issues/11
@@ -63,9 +64,6 @@ category: accessibility
 */
 /* @media (prefers-reduced-motion: reduce) {
   *, ::before, ::after {
-    animation-delay: -1ms !important;
-    animation-duration: 1ms !important;
-    animation-iteration-count: 1 !important;
     background-attachment: initial !important;
     scroll-behavior: auto !important;
     transition-delay: 0s !important;


### PR DESCRIPTION
animation properties can cause UI breakages on browsers that support these alternative timeline animations and reduced motion preference is active.

For example

```
@keyframes to-transparent {
  from {
    opacity: 1;
  }

  to {
    opacity: 0;
  }
}

.container {
  animation-name: to-opaque;
  animation-timeline: --scrollTimeline;
  animation-fill-mode: both;
}
```

will cause .container to be permanently transparent for users with reduced motion preference.